### PR TITLE
Add caps lock warning and difficulty scaling to typing game

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -264,3 +264,26 @@ h1 {
     scroll-behavior: auto !important;
   }
 }
+
+/* Monospace voor commando-weergave en input */
+.display, input#input { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; }
+
+/* Prefix highlighting in het doelwoord */
+.ok { color: var(--accent); }
+.err { text-decoration: underline; text-decoration-color: #ff5454; text-decoration-thickness: 2px; }
+input#input.err {
+  border-color: rgba(255, 84, 84, 0.85);
+  box-shadow: 0 0 0 3px rgba(255, 84, 84, 0.35);
+}
+
+/* Caps Lock banner */
+.caps {
+  margin: 8px 0;
+  padding: 8px 12px;
+  border: 1px solid rgba(255, 196, 0, 0.25);
+  background: rgba(255, 196, 0, 0.08);
+  color: #ffd666;
+  border-radius: 6px;
+  font-size: 14px;
+}
+.hidden { display: none; }

--- a/index.html
+++ b/index.html
@@ -14,38 +14,24 @@
       <p class="tagline">60 seconden pure focus zoals in de Tex-Tribe war room.</p>
     </header>
 
-    <section class="panel" aria-live="off">
-      <div class="display" id="display" aria-live="polite"></div>
-      <label for="input" class="sr-only">Typ het weergegeven woord</label>
-      <input id="input" type="text" inputmode="latin" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" aria-describedby="stats" disabled>
+    <section class="panel game" aria-labelledby="game-title">
+      <h2 id="game-title" class="sr-only">Typ-game</h2>
+      <div id="display" class="display" aria-live="polite">klaar? druk start</div>
 
-      <div class="stats" id="stats" role="status" aria-live="polite">
-        <div class="stat">
-          <svg class="icon" aria-hidden="true"><use href="assets/icons.svg#tachometer"></use></svg>
-          <span class="label">WPM</span>
-          <span id="wpm" class="value">0</span>
-        </div>
-        <div class="stat">
-          <svg class="icon" aria-hidden="true"><use href="assets/icons.svg#target"></use></svg>
-          <span class="label">Accuracy</span>
-          <span id="acc" class="value">100%</span>
-        </div>
-        <div class="stat">
-          <svg class="icon" aria-hidden="true"><use href="assets/icons.svg#timer"></use></svg>
-          <span class="label">Tijd</span>
-          <span id="time" class="value">60s</span>
-        </div>
+      <div id="caps" class="caps hidden" role="alert" aria-live="assertive">
+        Caps Lock staat aan, dit kan typefouten veroorzaken
       </div>
 
+      <input id="input" type="text" aria-label="Typ hier het commando" autofocus autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false" disabled />
+
+      <div class="stats" aria-live="polite">
+        <span id="wpm">WPM: 0</span>
+        <span id="acc">Acc: 100%</span>
+        <span id="time">Tijd: 60s</span>
+      </div>
       <div class="controls">
-        <button id="start" type="button" class="btn primary" aria-label="Start HackType">
-          <svg class="icon" aria-hidden="true"><use href="assets/icons.svg#play"></use></svg>
-          Start
-        </button>
-        <button id="reset" type="button" class="btn" aria-label="Reset HackType" disabled>
-          <svg class="icon" aria-hidden="true"><use href="assets/icons.svg#refresh"></use></svg>
-          Reset
-        </button>
+        <button id="start" type="button" class="btn primary" aria-label="Start HackType">Start</button>
+        <button id="reset" type="button" class="btn" aria-label="Reset HackType">Reset</button>
       </div>
     </section>
 
@@ -53,8 +39,6 @@
       <p>HackType by een Tex-Tribe geest — houd de terminal scherp.</p>
     </footer>
   </main>
-
-  <div id="live-region" class="sr-only" role="status" aria-live="polite"></div>
 
   <script src="js/app.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- replace the main game section to expose a caps-lock alert and simpler ARIA markup
- style the command display/input in monospace, highlight typed prefixes, and show the caps warning banner
- rebuild the game logic to detect caps lock, adapt word difficulty over time, and highlight matching prefixes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd379a7ca48326a068468f8af42039