### PR TITLE
Add local storage helpers for high scores and progress

### DIFF
--- a/src/storage/local/index.js
+++ b/src/storage/local/index.js
@@ -1,0 +1,277 @@
+/**
+ * Local storage helpers for HackType.
+ *
+ * The MVP needs a reliable way to persist high scores and light-weight
+ * progress so returning players keep their achievements. This module wraps
+ * `window.localStorage` with defensive guards so the game remains safe in
+ * privacy hardened browsers or offline contexts.
+ */
+
+const STORAGE_KEY = "hacktype::v1::profile";
+
+const DEFAULT_STATE = Object.freeze({
+  version: 1,
+  highScores: {},
+  progress: {
+    tutorialCompleted: false,
+    lastPackId: null,
+    packStats: {}
+  }
+});
+
+let memoryState = createDefaultState();
+
+function createDefaultState() {
+  return {
+    version: DEFAULT_STATE.version,
+    highScores: {},
+    progress: {
+      tutorialCompleted: DEFAULT_STATE.progress.tutorialCompleted,
+      lastPackId: DEFAULT_STATE.progress.lastPackId,
+      packStats: {}
+    }
+  };
+}
+
+function cloneState(state) {
+  return {
+    version: state.version,
+    highScores: { ...state.highScores },
+    progress: {
+      tutorialCompleted: Boolean(state.progress?.tutorialCompleted),
+      lastPackId: state.progress?.lastPackId ?? null,
+      packStats: Object.fromEntries(
+        Object.entries(state.progress?.packStats ?? {}).map(([packId, stats]) => [
+          packId,
+          {
+            attempts: Math.max(0, Math.floor(Number(stats.attempts) || 0)),
+            clears: Math.max(0, Math.floor(Number(stats.clears) || 0)),
+            bestScore: Math.max(0, Math.floor(Number(stats.bestScore) || 0))
+          }
+        ])
+      )
+    }
+  };
+}
+
+function getStorage() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    const { localStorage } = window;
+    const testKey = `${STORAGE_KEY}::test`;
+    localStorage.setItem(testKey, "1");
+    localStorage.removeItem(testKey);
+    return localStorage;
+  } catch (error) {
+    console.warn("HackType: localStorage unavailable, falling back to memory.", error);
+    return null;
+  }
+}
+
+const storage = getStorage();
+
+function readState() {
+  if (!storage) {
+    return cloneState(memoryState);
+  }
+
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) {
+      memoryState = createDefaultState();
+      return cloneState(memoryState);
+    }
+    const parsed = JSON.parse(raw);
+    memoryState = normaliseState(parsed);
+    return cloneState(memoryState);
+  } catch (error) {
+    console.warn("HackType: failed to read profile state, resetting.", error);
+    memoryState = createDefaultState();
+    if (storage) {
+      try {
+        storage.removeItem(STORAGE_KEY);
+      } catch (removeError) {
+        console.warn("HackType: failed to clear corrupted localStorage entry.", removeError);
+      }
+    }
+    return cloneState(memoryState);
+  }
+}
+
+function writeState(state) {
+  memoryState = normaliseState(state);
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(memoryState));
+  } catch (error) {
+    console.warn("HackType: failed to persist profile state.", error);
+  }
+}
+
+function normaliseState(rawState) {
+  if (!rawState || typeof rawState !== "object") {
+    return createDefaultState();
+  }
+
+  const base = createDefaultState();
+  const safeHighScores = {};
+
+  if (rawState.highScores && typeof rawState.highScores === "object") {
+    for (const [modeId, score] of Object.entries(rawState.highScores)) {
+      const numericScore = Math.max(0, Math.floor(Number(score) || 0));
+      if (modeId) {
+        safeHighScores[modeId] = numericScore;
+      }
+    }
+  }
+
+  const safeProgress = {
+    tutorialCompleted: Boolean(rawState.progress?.tutorialCompleted),
+    lastPackId: rawState.progress?.lastPackId ?? base.progress.lastPackId,
+    packStats: {}
+  };
+
+  const packStats = rawState.progress?.packStats;
+  if (packStats && typeof packStats === "object") {
+    for (const [packId, stats] of Object.entries(packStats)) {
+      if (!packId || typeof stats !== "object") {
+        continue;
+      }
+      safeProgress.packStats[packId] = {
+        attempts: Math.max(0, Math.floor(Number(stats.attempts) || 0)),
+        clears: Math.max(0, Math.floor(Number(stats.clears) || 0)),
+        bestScore: Math.max(0, Math.floor(Number(stats.bestScore) || 0))
+      };
+    }
+  }
+
+  return {
+    version: Number.isFinite(rawState.version) ? rawState.version : base.version,
+    highScores: safeHighScores,
+    progress: safeProgress
+  };
+}
+
+function updateState(mutator) {
+  const current = readState();
+  const draft = cloneState(current);
+  const next = mutator(draft) || draft;
+  writeState(next);
+  return readState();
+}
+
+export function getHighScore(modeId = "core") {
+  const state = readState();
+  return state.highScores[modeId] ?? 0;
+}
+
+export function recordScore({ modeId = "core", score = 0, packId = null, completed = false } = {}) {
+  const numericScore = Math.max(0, Math.floor(Number(score) || 0));
+
+  let updatedState;
+  updateState((state) => {
+    const currentHigh = state.highScores[modeId] ?? 0;
+    if (numericScore > currentHigh) {
+      state.highScores[modeId] = numericScore;
+    }
+
+    if (packId) {
+      const packStats = state.progress.packStats[packId] ?? {
+        attempts: 0,
+        clears: 0,
+        bestScore: 0
+      };
+      packStats.attempts += 1;
+      if (completed) {
+        packStats.clears += 1;
+      }
+      if (numericScore > packStats.bestScore) {
+        packStats.bestScore = numericScore;
+      }
+      state.progress.packStats[packId] = packStats;
+      state.progress.lastPackId = packId;
+    }
+
+    updatedState = state;
+    return state;
+  });
+
+  return {
+    highScore: updatedState.highScores[modeId] ?? numericScore,
+    pack: packId ? updatedState.progress.packStats[packId] : undefined
+  };
+}
+
+export function getProgress() {
+  const state = readState();
+  return cloneState({
+    version: state.version,
+    highScores: {},
+    progress: state.progress
+  }).progress;
+}
+
+export function markTutorialCompleted() {
+  return updateState((state) => {
+    if (!state.progress.tutorialCompleted) {
+      state.progress.tutorialCompleted = true;
+    }
+    return state;
+  }).progress.tutorialCompleted;
+}
+
+export function resetProfile() {
+  writeState(createDefaultState());
+  if (storage) {
+    try {
+      storage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      console.warn("HackType: failed to clear stored profile.", error);
+    }
+  }
+  return readState();
+}
+
+export function getPackStats(packId) {
+  if (!packId) {
+    return null;
+  }
+  const { packStats } = readState().progress;
+  const stats = packStats[packId];
+  if (!stats) {
+    return {
+      attempts: 0,
+      clears: 0,
+      bestScore: 0
+    };
+  }
+  return { ...stats };
+}
+
+export function updatePackStats(packId, patch = {}) {
+  if (!packId) {
+    return getPackStats(packId);
+  }
+  const updated = updateState((state) => {
+    const current = state.progress.packStats[packId] ?? {
+      attempts: 0,
+      clears: 0,
+      bestScore: 0
+    };
+    state.progress.packStats[packId] = {
+      attempts: Math.max(0, Math.floor(Number(patch.attempts ?? current.attempts) || 0)),
+      clears: Math.max(0, Math.floor(Number(patch.clears ?? current.clears) || 0)),
+      bestScore: Math.max(0, Math.floor(Number(patch.bestScore ?? current.bestScore) || 0))
+    };
+    return state;
+  });
+  return { ...updated.progress.packStats[packId] };
+}
+
+export function getProfileSnapshot() {
+  return readState();
+}

--- a/tasks.md
+++ b/tasks.md
@@ -12,7 +12,7 @@ Legend: `[ ]` To do, `[x]` Done, `(review)` needs review, `(blocked)` blocked.
 * [x] **P1-002, Typing validation baseline**, char level accuracy, command complete detection, output: `src/logic/typing`
 * [x] **P1-003, Scoring baseline**, base points, time bonus, error penalties, output: `src/logic/scoring`
 * [x] **P1-004, Beginner command pack**, 30 to 50 safe hacker-themed commands with mock outputs, output: `content/packs/beginner.json`
-* [ ] **P1-005, Local storage basics**, highscores and simple progress, output: `src/storage/local`
+* [x] **P1-005, Local storage basics**, highscores and simple progress, output: `src/storage/local`
 * [ ] **P1-006, Basic audio cues**, correct, error, level up, output: `assets/audio` and `src/audio`
 * [ ] **P1-007, Basic animations**, success glow, error shake, output: `src/ui/animations`
 * [ ] **P1-008, Onboarding tutorial**, 60 second tutorial, output: `src/ui/onboarding`


### PR DESCRIPTION
## Summary
- add a guarded local storage profile module that persists high scores and per-pack progress
- expose helpers to record scores, mark tutorial completion, and reset the profile state
- normalise stored values to stay resilient against malformed or missing data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decad9d4f8832695c9fa3713e31399