### PR TITLE
feat: add toggle for game audio

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -51,8 +51,20 @@ body {
 }
 
 .top {
-  text-align: center;
+  display: grid;
+  gap: 12px;
   margin-bottom: 28px;
+}
+
+.top-line {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.top-line h1 {
+  flex: 1;
+  text-align: center;
 }
 
 h1 {
@@ -64,9 +76,56 @@ h1 {
 }
 
 .tagline {
-  margin: 8px 0 0;
+  margin: 0;
   color: var(--muted);
   font-size: 0.95rem;
+  text-align: center;
+}
+
+.audio-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(61, 250, 114, 0.25);
+  background: rgba(8, 16, 20, 0.8);
+  color: var(--text);
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, background 0.2s ease;
+}
+
+.audio-toggle[aria-pressed="false"] {
+  opacity: 0.7;
+  border-color: rgba(61, 250, 114, 0.18);
+  background: rgba(8, 16, 20, 0.6);
+}
+
+.audio-toggle[disabled] {
+  opacity: 0.35;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.audio-toggle:focus-visible,
+.audio-toggle:hover {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 18px rgba(61, 250, 114, 0.4);
+  transform: translateY(-1px);
+}
+
+.audio-toggle-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.audio-toggle-label {
+  line-height: 1;
 }
 
 .screen {

--- a/index.html
+++ b/index.html
@@ -10,7 +10,13 @@
 <body>
   <main id="app" class="shell" aria-labelledby="page-title">
     <header class="top">
-      <h1 id="page-title">HackType</h1>
+      <div class="top-line">
+        <h1 id="page-title">HackType</h1>
+        <button type="button" class="audio-toggle" data-action="toggle-audio" aria-pressed="true">
+          <span class="audio-toggle-icon" aria-hidden="true">🔊</span>
+          <span class="audio-toggle-label" data-audio-label>Geluid aan</span>
+        </button>
+      </div>
       <p class="tagline">60 seconden pure focus zoals in de Tex-Tribe war room.</p>
     </header>
 

--- a/src/storage/local/index.js
+++ b/src/storage/local/index.js
@@ -15,7 +15,8 @@ const DEFAULT_STATE = Object.freeze({
   progress: {
     tutorialCompleted: false,
     lastPackId: null,
-    packStats: {}
+    packStats: {},
+    audioEnabled: true
   }
 });
 
@@ -28,7 +29,8 @@ function createDefaultState() {
     progress: {
       tutorialCompleted: DEFAULT_STATE.progress.tutorialCompleted,
       lastPackId: DEFAULT_STATE.progress.lastPackId,
-      packStats: {}
+      packStats: {},
+      audioEnabled: DEFAULT_STATE.progress.audioEnabled
     }
   };
 }
@@ -49,7 +51,8 @@ function cloneState(state) {
             bestScore: Math.max(0, Math.floor(Number(stats.bestScore) || 0))
           }
         ])
-      )
+      ),
+      audioEnabled: state.progress?.audioEnabled !== false
     }
   };
 }
@@ -132,7 +135,8 @@ function normaliseState(rawState) {
   const safeProgress = {
     tutorialCompleted: Boolean(rawState.progress?.tutorialCompleted),
     lastPackId: rawState.progress?.lastPackId ?? base.progress.lastPackId,
-    packStats: {}
+    packStats: {},
+    audioEnabled: rawState.progress?.audioEnabled !== false
   };
 
   const packStats = rawState.progress?.packStats;
@@ -213,6 +217,19 @@ export function getProgress() {
     highScores: {},
     progress: state.progress
   }).progress;
+}
+
+export function getAudioEnabled() {
+  return readState().progress.audioEnabled !== false;
+}
+
+export function setAudioEnabled(value) {
+  const enabled = value !== false;
+  const updated = updateState((state) => {
+    state.progress.audioEnabled = enabled;
+    return state;
+  });
+  return updated.progress.audioEnabled !== false;
 }
 
 export function markTutorialCompleted() {


### PR DESCRIPTION
## Summary
- add a header control to switch HackType sound effects on or off
- persist the audio preference locally and sync the UI with stored state
- style the new toggle button and handle browsers without Web Audio support

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e503beb99c8326aa8e6312fbdccdc1