### PR TITLE
feat: split audio controls for music and effects

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -82,6 +82,14 @@ h1 {
   text-align: center;
 }
 
+.audio-toggle-group {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+}
+
 .audio-toggle {
   display: inline-flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -12,10 +12,16 @@
     <header class="top">
       <div class="top-line">
         <h1 id="page-title">HackType</h1>
-        <button type="button" class="audio-toggle" data-action="toggle-audio" aria-pressed="true">
-          <span class="audio-toggle-icon" aria-hidden="true">🔊</span>
-          <span class="audio-toggle-label" data-audio-label>Geluid aan</span>
-        </button>
+        <div class="audio-toggle-group" role="group" aria-label="Audio">
+          <button type="button" class="audio-toggle" data-action="toggle-music" aria-pressed="true">
+            <span class="audio-toggle-icon" aria-hidden="true">🎵</span>
+            <span class="audio-toggle-label" data-music-label>Muziek aan</span>
+          </button>
+          <button type="button" class="audio-toggle" data-action="toggle-effects" aria-pressed="true">
+            <span class="audio-toggle-icon" aria-hidden="true">🎯</span>
+            <span class="audio-toggle-label" data-effects-label>Effecten aan</span>
+          </button>
+        </div>
       </div>
       <p class="tagline">60 seconden pure focus zoals in de Tex-Tribe war room.</p>
     </header>


### PR DESCRIPTION
## Summary
- replace the single audio toggle with separate music and effects buttons and refreshed styling
- update the audio controller and bootstrap logic to respect independent music/effect states
- persist the new audio preferences structure in local storage

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e64949092c8326996ce142c841dc01